### PR TITLE
Use echo and pipe to get upload data into curl

### DIFF
--- a/codecov
+++ b/codecov
@@ -318,11 +318,12 @@ then
   echo "$upload"
 else
   say "Uploading reports"
-  res=$(curl -X POST \
-             --silent \
-             -d "$upload" \
-             -H "Content-Type: text/plain" \
-             "$url/upload/v2?$query")
+  res=$(echo "$upload" | \
+            curl -X POST \
+                 --silent \
+                 -d @- \
+                 -H "Content-Type: text/plain" \
+                 "$url/upload/v2?$query")
   echo "$(json "$res")"
 fi
 


### PR DESCRIPTION
When using the script, I was seeing "Argument list too long" errors with the `curl` command, presumably because of the length of `$upload`.  Using `echo` to get the content of `$upload` and piping it into `curl` with `-d @-` to read data from the pipe works in the case where I had been getting the "Argument list too long" error.