### PR TITLE
Handle newlines in .bowerrc

### DIFF
--- a/codecov
+++ b/codecov
@@ -58,8 +58,7 @@ urlencode() {
 bower_components="bower_components"
 if [ -f .bowerrc ];
 then
-  bowerrc=$(cat .bowerrc)
-  bower_components=$(python -c "import json as j; print j.loads('$bowerrc').get('directory', 'bower_components')")
+  bower_components=$(python -c "import json as j; print j.load(open('.bowerrc')).get('directory', 'bower_components')")
 fi
 
 if [ $# != 0 ];


### PR DESCRIPTION
When setting $bower_components, the .bowerrc file was first read into
an environment variable, an this variable was then embedded in a
$(python -c "...") construct. This failed for my build due to newlines
in the .bowerrc file:
```
$ bash <(curl -s https://codecov.io/bash)
  File "<string>", line 1
    import json as j; print j.loads('{
                                     ^
SyntaxError: EOL while scanning string literal
```
We now simply let the Python JSON module read the .bowerrc file.