### PR TITLE
Correct the application of the -g option

### DIFF
--- a/codecov
+++ b/codecov
@@ -125,8 +125,7 @@ then
         fi
         ;;
       "g")
-        gcov_ignore="$gcov_ignore
--not -path '$OPTARG'"
+        gcov_ignore="$gcov_ignore -not -path '$OPTARG'"
         ;;
       "x")
         gcov_exe=$OPTARG


### PR DESCRIPTION
Prior to this change, using the -g option results the following bash error:

```
~/src/codecov-bash$ ./codecov -g test
Codecov v0.0.6
(url) https://codecov.io
==> No CI detected, using git for branch and commit sha.
==> find . -type f -name '*.gcno'
-not -path 'test' -exec gcov  {} +
bash: line 1: -not: command not found
```

This is because bash interprets an extraneous new-line character as a command terminator, and thus tries to execute a `-not ...` command.

This change simply removes the extraneous new-line character, resulting in the relevant `find` command being built correctly (at least for bash 4.3.30).

After this change, the above test is as follows:

```
~/src/codecov-bash$ ./codecov -g test
Codecov v0.0.6
(url) https://codecov.io
==> No CI detected, using git for branch and commit sha.
==> find . -type f -name '*.gcno'  -not -path 'test' -exec gcov  {} +
==> Searching for coverage reports
==> No coverage report found.
```

Where the `find` command is now correct.

Cheers.