### PR TITLE
include Rscript

### DIFF
--- a/codecov
+++ b/codecov
@@ -383,13 +383,20 @@ coverage.xml"
 fi
 
 # R lang: include jimhester/covr package
-if [ "$rlang" = "0" ]; then
+Rscript_report=""
+if [ "$rlang" = "0" ];
+then
   say "==> Skipped Rscript"
-elif which Rscript >/dev/null 2>&1; then
+elif which Rscript >/dev/null 2>&1;
+then
   say "==> Running Rscript jimhester/covr"
-  Rscript -e 'if (!require("devtools")) install.packages("devtools")' \
-          -e 'devtools::install_github("jimhester/covr")' \
-          -e 'covr::codecov()' || true
+  Rscript_report=$(Rscript -e 'if (!require("devtools")) install.packages("devtools")' \
+                           -e 'devtools::install_github("codecov/Rscript-covr")' \
+                           -e 'covr::codecov()' || true)
+  if [ "$Rscript_report" != "" ] && [ "$files" = "" ];
+  then
+    files=1
+  fi
 else
   say "==> No Rscript command found"
 fi
@@ -436,22 +443,34 @@ then
 fi
 
 say "==> Reading reports"
-for file in $files
-do
-  # escape file paths
-  file="$(echo $file | sed -e 's/ /\\ /')"
-  # read the coverage file
-  if [ -f "$file" ];
-  then
-    saymore "--> read: $file"
-    report=$(cat "$file")
-    # append to to upload
-    upload="$upload
+if [ "$files" != "1" ];
+then
+  for file in $files
+  do
+    # escape file paths
+    file="$(echo $file | sed -e 's/ /\\ /')"
+    # read the coverage file
+    if [ -f "$file" ];
+    then
+      saymore "--> read: $file"
+      report=$(cat "$file")
+      # append to to upload
+      upload="$upload
 <<<<<< EOF
 $report"
-  fi
-done
+    fi
+  done
+fi
 
+# add Rscript report
+if [ "$Rscript_report" != "" ];
+then
+  upload="$upload
+<<<<<< EOF
+$Rscript_report"
+fi
+
+# add environment variables
 if [ "$env" ] || [ "$CODECOV_ENV" ];
 then
   for e in $(echo "$CODECOV_ENV" | tr ',' ' ')

--- a/codecov
+++ b/codecov
@@ -14,6 +14,7 @@ dump=0
 files=0
 gcov_ignore=""
 gcov=1
+rlang=1
 proj_root="."
 gcov_exe="gcov"
 gcov_arg=""
@@ -39,10 +40,10 @@ Upload reports to Codecov
                  ex. codecov -r mycompany/home
     -v           Verbose Mode
     -d           Dont upload and dump to stdin
-    -X feature   Disable functionalities, accepting: 'gcov'
+    -X feature   Disable functionalities, accepting: gcov, Rscript
     -g GLOB      Paths to ignore during gcov gathering
     -p dir       Project root used when preparing gcov
-    -x gcovexe   gcov executable to run. Defaults to 'gcov'
+    -x gcovexe   gcov executable to run. Defaults to gcov
     -a gcovargs  extra arguments to pass o gcov
     -s silent    Enable silent mode
 
@@ -122,6 +123,9 @@ then
         if [ "$OPTARG" = "gcov" ];
         then
           gcov=0
+        elif [ "$OPTARG" = "Rscript" ];
+        then
+          rlang=0
         fi
         ;;
       "g")
@@ -328,7 +332,7 @@ then
   # all other gcov
   bash -c "find $proj_root -type f -name '*.gcno' $gcov_ignore -exec $gcov_exe $gcov_arg {} +" || true
 else
-  say '==> gcov disable'
+  say '==> Skipped gcov'
 fi
 
 # find all the reports
@@ -376,6 +380,18 @@ coverage.xml"
       say "No data to report"
     fi
   fi
+fi
+
+# R lang: include jimhester/covr package
+if [ "$rlang" = "0" ]; then
+  say "==> Skipped Rscript"
+elif which Rscript >/dev/null 2>&1; then
+  say "==> Running Rscript jimhester/covr"
+  Rscript -e 'if (!require("devtools")) install.packages("devtools")' \
+          -e 'devtools::install_github("jimhester/covr")' \
+          -e 'covr::codecov()' || true
+else
+  say "==> No Rscript command found"
 fi
 
 # no files found

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -17,10 +17,9 @@ Upload reports to Codecov
                  ex. codecov -r mycompany/home
     -v           Verbose Mode
     -d           Dont upload and dump to stdin
-    -X feature   Disable functionalities, accepting: 'gcov'
     -g GLOB      Paths to ignore during gcov gathering
     -p dir       Project root used when preparing gcov
-    -x gcovexe   gcov executable to run. Defaults to 'gcov'
+    -x gcovexe   gcov executable to run. Defaults to gcov
     -a gcovargs  extra arguments to pass o gcov
     -s silent    Enable silent mode
 

--- a/tests/test
+++ b/tests/test
@@ -151,7 +151,7 @@ function test_token_env () {
 
 function test_verbose_opt () {
     reset
-    assertDiff "$(./codecov -vd | grep -v 'coverage cli exists')" ./tests/verbose.txt
+    assertDiff "$(./codecov -vd | grep -v 'coverage cli exists' | grep -v 'branch was HEAD')" ./tests/verbose.txt
 }
 
 function test_upload () {

--- a/tests/test
+++ b/tests/test
@@ -12,7 +12,7 @@ export _VERSION="$VERSION"
 export PATH=$PWD:$PATH
 
 function reset () {
-    rm -rf temp bower .bowerrc coverage
+    rm -rf temp bower .bowerrc coverage Rscript
     mkdir -p temp
     mkdir -p ~/Library/Developer/Xcode/DerivedData
     install -b -m 755 /dev/null coverage
@@ -24,7 +24,7 @@ function reset () {
 }
 
 function assertDiff () {
-    diff <(erb "$2") <(echo "$1")
+    diff <(erb "$2") <(echo "$1" | grep -v 'Rscript')
     assertTrue 'Expected output differs.' $?
 }
 
@@ -117,9 +117,23 @@ function test_slug_env () {
     assertURL "https://codecov.io/upload/v2?package=bash-v$VERSION&branch=$_BRANCH&commit=$_SHA&slug=myowner/myrepo"
 }
 
+function test_rscript () {
+    reset
+    ./codecov -dv -X Rscript | grep '==> Skipped Rscript'
+    assertTrue 'Rscript was disabled' $?
+}
+
+function test_rscript_raises_no_errors () {
+    reset
+    install -b -m 755 /dev/null Rscript
+    echo "exit 1;" > Rscript
+    ./codecov -dv | grep '==> Running Rscript jimhester/covr'
+    assertTrue 'Rscript raises no errors' $?
+}
+
 function test_gcov () {
     reset
-    ./codecov -dv -X gcov | grep '==> gcov disable'
+    ./codecov -dv -X gcov | grep '==> Skipped gcov'
     assertTrue 'gcov was disabled' $?
 }
 


### PR DESCRIPTION
> cc @jimhester, https://github.com/OHDSI/Cyclops/pull/20
### Goal

> Reduce installation requirements for R lang. We are hoping to streamline the dependancies to make integration with Codecov quicker and easier. Using the Bash uploader comes with many other features and integration including (a) storing environment variables, (b) ci variable collection and (c) gathering other reports.
##### Before

``` yml
r_github_packages:
  - jimhester/covr
after_success:
  - Rscript -e 'library(covr); codecov()'
```
##### After

``` yml
after_success:
  - bash <(curl -s https://codecov.io/bash)
```

> [Read more about Codecov Bash](https://github.com/codecov/codecov-bash)
### Todo
- [ ] stdout coverage data from [codecov/Rscript-covr](https://github.com/codecov/Rscript-covr)
### CLI Additions
- disabled Rscript via `-X Rscript`
