### PR TITLE
Ignore SCons temporary files

### DIFF
--- a/codecov
+++ b/codecov
@@ -395,7 +395,8 @@ else
                     -not -path '*/__pycache__/*' \
                     -not -path '*/.egg-info*' \
                     -not -path "*/$bower_components/*" \
-                    -not -path '*/node_modules/*')
+                    -not -path '*/node_modules/*' \
+                    -not -path '*/conftest_*.c.gcov')
 
   # Python coveragepy generation
   if [ "$ft_coveragepy" = "1" ];


### PR DESCRIPTION
Hello,

SCons generates and runs small C programs in the directory `.sconf_temp` to test for features (like Autoconf). When building with the `-coverage` option for GCC, these files are also built with this option, are run, and generate `.gcno` files. These are then found by the `codecov` Bash script, and skew your reports.

So I added the option `-g './scon*` to the command `bash <(curl -s https://codecov.io/bash)` in my Travis CI configuration file. But it would be nice to ignore these by default.