### PR TITLE
Bitrise CI support

### DIFF
--- a/codecov
+++ b/codecov
@@ -294,9 +294,9 @@ then
   branch="$BITRISE_GIT_BRANCH"
   build="$BITRISE_BUILD_NUMBER"
   build_url=$(urlencode "$BITRISE_BUILD_URL")
-  slug="$BITRISE_APP_SLUG"
+  slug="app/$BITRISE_APP_SLUG"
   pr="$BITRISE_PULL_REQUEST"
-  commit="$BITRISE_GIT_COMMIT"
+  commit=$([ "$BITRISE_GIT_COMMIT" != "" ] && echo "$BITRISE_GIT_COMMIT" || echo $(git rev-parse HEAD || hg id -i --debug | tr -d '+'))
 
 elif [ "$CI" = "true" ] && [ "$SEMAPHORE" = "true" ];
 then

--- a/codecov
+++ b/codecov
@@ -294,7 +294,6 @@ then
   branch="$BITRISE_GIT_BRANCH"
   build="$BITRISE_BUILD_NUMBER"
   build_url=$(urlencode "$BITRISE_BUILD_URL")
-  slug="app/$BITRISE_APP_SLUG"
   pr="$BITRISE_PULL_REQUEST"
   commit=$([ "$BITRISE_GIT_COMMIT" != "" ] && echo "$BITRISE_GIT_COMMIT" || echo $(git rev-parse HEAD || hg id -i --debug | tr -d '+'))
 

--- a/tests/test
+++ b/tests/test
@@ -223,7 +223,7 @@ function test_bitrise (){
     export BITRISE_BUILD_NUMBER="15.1"
     export BITRISE_PULL_REQUEST="1"
     export BITRISE_BUILD_URL="http://endpoint"
-    assertURL "https://codecov.io/upload/v2?package=bash-$VERSION&branch=develop&commit=180c0d097354fc1a451da8a3be5aba255f2ffd9f&build=15.1&build_url=http%3A%2F%2Fendpoint&service=bitrise&pr=1&job="
+    assertURL "https://codecov.io/upload/v2?package=bash-$VERSION&branch=develop&commit=180c0d097354fc1a451da8a3be5aba255f2ffd9f&build=15.1&build_url=http%3A%2F%2Fendpoint&slug=&service=bitrise&pr=1&job="
 }
 
 function test_jenkins_vars (){

--- a/tests/test
+++ b/tests/test
@@ -218,13 +218,12 @@ function test_bitrise (){
     reset
     export CI="true"
     export BITRISE_IO="true"
-    export BITRISE_APP_SLUG="asd1234"
     export BITRISE_GIT_BRANCH="develop"
     export BITRISE_GIT_COMMIT="180c0d097354fc1a451da8a3be5aba255f2ffd9f"
     export BITRISE_BUILD_NUMBER="15.1"
     export BITRISE_PULL_REQUEST="1"
     export BITRISE_BUILD_URL="http://endpoint"
-    assertURL "https://codecov.io/upload/v2?package=bash-$VERSION&branch=develop&commit=180c0d097354fc1a451da8a3be5aba255f2ffd9f&build=15.1&build_url=http%3A%2F%2Fendpoint&slug=app/asd1234&service=bitrise&pr=1&job="
+    assertURL "https://codecov.io/upload/v2?package=bash-$VERSION&branch=develop&commit=180c0d097354fc1a451da8a3be5aba255f2ffd9f&build=15.1&build_url=http%3A%2F%2Fendpoint&service=bitrise&pr=1&job="
 }
 
 function test_jenkins_vars (){

--- a/tests/test
+++ b/tests/test
@@ -218,13 +218,13 @@ function test_bitrise (){
     reset
     export CI="true"
     export BITRISE_IO="true"
-    export BITRISE_APP_SLUG="owner/repo"
+    export BITRISE_APP_SLUG="asd1234"
     export BITRISE_GIT_BRANCH="develop"
     export BITRISE_GIT_COMMIT="180c0d097354fc1a451da8a3be5aba255f2ffd9f"
     export BITRISE_BUILD_NUMBER="15.1"
     export BITRISE_PULL_REQUEST="1"
     export BITRISE_BUILD_URL="http://endpoint"
-    assertURL "https://codecov.io/upload/v2?package=bash-$VERSION&branch=develop&commit=180c0d097354fc1a451da8a3be5aba255f2ffd9f&build=15.1&build_url=http%3A%2F%2Fendpoint&slug=owner/repo&service=bitrise&pr=1&job="
+    assertURL "https://codecov.io/upload/v2?package=bash-$VERSION&branch=develop&commit=180c0d097354fc1a451da8a3be5aba255f2ffd9f&build=15.1&build_url=http%3A%2F%2Fendpoint&slug=app/asd1234&service=bitrise&pr=1&job="
 }
 
 function test_jenkins_vars (){


### PR DESCRIPTION
slug changed for Bitrise
Bitrise won't generate `BITRISE_GIT_COMMIT` if the build was started manually