### PR TITLE
Remove token from output

### DIFF
--- a/codecov
+++ b/codecov
@@ -669,9 +669,9 @@ $adjustments
   fi
 fi
 
+say "$e(query)$x package=bash-$VERSION&$query"
 # trim whitespace from query
 query=$(echo "package=bash-$VERSION&$query$token" | tr -d ' ')
-say "$e(query)$x $query"
 
 if [ "$dump" != "0" ];
 then


### PR DESCRIPTION
Prevent printing the token to stdout by printing before appending the token.

This change should fix #22.

Whitespace is not removed before printing, but this should be acceptable as it's only used for debugging purposes.