### PR TITLE
Fix out of source build

### DIFF
--- a/codecov
+++ b/codecov
@@ -655,6 +655,7 @@ else
                     -not -name 'coverage.html' \
                     -not -name 'scoverage.measurements.*' \
                     -not -name 'test_*_coverage.txt' \
+                    -not -name '*.cmake' \
                     -not -path '*/vendor/*' \
                     -not -path '*/htmlcov/*' \
                     -not -path '*/home/cainus/*' \

--- a/codecov
+++ b/codecov
@@ -613,8 +613,8 @@ else
     say "${r}**>${x} gcov disable"
   fi
 
-  say "$e==>$x Searching for coverage reports"
-  search_in="$search_in $git_root"
+  search_in="$search_in $proj_root"
+  say "$e==>$x Searching for coverage reports under: $search_in"
   files=$(find $search_in -type f \( -name '*coverage.*' \
                      -or -name 'nosetests.xml' \
                      -or -name 'jacoco*.xml' \


### PR DESCRIPTION
This fixes a mis-identification of a source file as coverage report and the search for reports in a out-of-source build (in a CMake based C++ project).

See also:
- https://github.com/gsauthof/libxfsx/commit/896cc0562116dd1b916f61152c769067a2065167
- https://github.com/gsauthof/libxfsx/commit/3f5fd67101439649a82743cb823b7ac13dd4df50

Both changes are tested in an older version of the script.