### PR TITLE
Detect Shippable as such, instead of as Travis.

### DIFF
--- a/codecov
+++ b/codecov
@@ -325,7 +325,7 @@ then
   pr="$ghprbPullId"
   build_url=$(urlencode "$BUILD_URL")
 
-elif [ "$CI" = "true" ] && [ "$TRAVIS" = "true" ];
+elif [ "$CI" = "true" ] && [ "$TRAVIS" = "true" ] && [ "$SHIPPABLE" != "true" ];
 then
   say "$e==>$x Travis CI detected."
   # http://docs.travis-ci.com/user/ci-environment/#Environment-variables


### PR DESCRIPTION
Shippable provides Travis compatible environment variables: http://docs.shippable.com/ci_configure/#travis-compatible-variables

When detecting Travis, make sure the environment isn't Shippable.