### PR TITLE
Bug in Generating Coverage Data for Xcode OS X Projects

### DIFF
--- a/codecov
+++ b/codecov
@@ -144,10 +144,10 @@ swiftcov() {
             else # coverage data: remove source from file
               echo "${line%|*}"
             fi
-          done < <(xcrun llvm-cov show -instr-profile "$1" "$f/$_proj") >> "$_proj_name.$_type.coverage.txt" \
+          done < <(xcrun llvm-cov show -instr-profile "$1" "$f/Contents/MacOS/$_proj") >> "$_proj_name.$_type.coverage.txt" \
                || echo "    ${r}**>${x} llvm-cov failed to produce results for $f/$_proj"
         else
-          xcrun llvm-cov show -instr-profile "$1" "$f/$_proj" > "$_proj_name.$_type.coverage.txt" \
+          xcrun llvm-cov show -instr-profile "$1" "$f/Contents/MacOS/$_proj" > "$_proj_name.$_type.coverage.txt" \
            || echo "    ${r}**>${x} llvm-cov failed to produce results for $f/$_proj"
         fi
       fi

--- a/codecov
+++ b/codecov
@@ -628,8 +628,9 @@ else
     # xcode via profdata
     if [ "$xp" = "" ];
     then
-      xp=$(xcodebuild -showBuildSettings 2>/dev/null | grep -i "^\s*PRODUCT_NAME" | sed -e 's/.*= \(.*\)/\1/')
-      say "  ${e}->${x} Speed up XCode processing by adding ${e}-J '$xp'${x}"
+      # xp=$(xcodebuild -showBuildSettings 2>/dev/null | grep -i "^\s*PRODUCT_NAME" | sed -e 's/.*= \(.*\)/\1/')
+      # say "  ${e}->${x} Speed up XCode processing by adding ${e}-J '$xp'${x}"
+      say "  ${e}->${x} Speed up xcode processing by using use -J 'AppName'"
     fi
 
     while read -r profdata;


### PR DESCRIPTION
Hi,

your script to generate coverage data for Xcode iOS projects works perfectly, but for OS X projects it fails. The reasons seems to be a different directory structure of the xctest folder.

For iOS projects the test binary is located in $project.xctest, for OS X projects it is in $project.xctest/Contents/MacOS.

My pull request contains a hotfix for OS X projects, but it will not work for iOS projects. Maybe you can extend the script to detect both project types.

Regards,
sundance