### PR TITLE
Improve find excludes

### DIFF
--- a/codecov
+++ b/codecov
@@ -725,6 +725,8 @@ else
                     -not -name '.coverage*' \
                     -not -name '.*coveragerc' \
                     -not -name '*.sh' \
+                    -not -name '*.bat' \
+                    -not -name '*.ps1' \
                     -not -name '*.log' \
                     -not -name '*.cmake' \
                     -not -name '*.pth' \

--- a/codecov
+++ b/codecov
@@ -757,7 +757,6 @@ else
                     -not -name '*.db' \
                     -not -name '*.md' \
                     -not -name '*.cpp' \
-                    -not -name '*.cmake' \
                     -not -name '*.gradle' \
                     -not -name '*.tar.tz' \
                     -not -name '*.scss' \


### PR DESCRIPTION
- Removes double exclusion of .cmake
- Adds .bat and .ps1 to list