### PR TITLE
bash is not guaranteed to be in /bin/bash

### DIFF
--- a/codecov
+++ b/codecov
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e +o pipefail
 


### PR DESCRIPTION
This updates the script to use /usr/bin/env to locate bash, so in environments (such as FreeBSD) where it is not always in /bin/bash it won't fail (unless, of course, bash is not installed at all)