### PR TITLE
sh compatibility

### DIFF
--- a/codecov
+++ b/codecov
@@ -1076,7 +1076,7 @@ do
       say "    ${r}-${x} file not found at $file"
     fi
   fi
-done <<< "$(echo -e "$files")"
+done <<< "$(echo -e $files)"
 
 if [ "$fr" = "0" ];
 then

--- a/readme.md
+++ b/readme.md
@@ -105,3 +105,13 @@ Bash does not respect multiple spaces with arguments
 - bash <(curl -s https://codecov.io/bash) -X coveragepy  -B master
 + bash <(curl -s https://codecov.io/bash) -X coveragepy -B master
 ```
+
+#### Fastlane
+
+```
+# fastlane no arguments
+sh("cd .. && curl -s http://codecov.io/bash | bash")
+
+# fastlane with arguments
+"curl -s http://codecov.io/bash | bash -s -- -J 'App1'")
+```


### PR DESCRIPTION
I was using codecov script with sh and came across an issue where the "-e " would be prefixed to the first coverage file found.

Since there are no examples on how to use this with fastlane, I also added an example to the readme file. 