### PR TITLE
Improve gitlab ci

### DIFF
--- a/codecov
+++ b/codecov
@@ -590,13 +590,17 @@ then
 elif [ "$GITLAB_CI" != "" ];
 then
   say "$e==>$x GitLab CI detected."
-  # http://doc.gitlab.com/ce/ci/variables/README.html
+  # https://docs.gitlab.com/ce/ci/variables/
   service="gitlab"
   branch="$CI_BUILD_REF_NAME"
   build="$CI_BUILD_ID"
-  remove_addr="$CI_BUILD_REPO"
+  if [ -n "$CI_PROJECT_URL" ] ; then
+    build_url="$CI_PROJECT_URL/builds/$CI_BUILD_ID"
+  fi
+  tag="$CI_BUILD_TAG"
   commit="$CI_BUILD_REF"
-
+  slug="$CI_PROJECT_PATH"
+  job="$CI_PIPELINE_ID"
 else
   say "${r}x>${x} No CI provider detected."
 

--- a/env
+++ b/env
@@ -183,6 +183,10 @@ then
   add "CI_BUILD_ID"
   add "CI_BUILD_REPO"
   add "CI_BUILD_REF"
+  add "CI_BUILD_TAG"
+  add "CI_PIPELINE_ID"
+  add "CI_PROJECT_PATH"
+  add "CI_PROJECT_URL"
 
 else
   add "VCS_COMMIT_ID"


### PR DESCRIPTION
Added more env variables defined by the latest Gitlab CI, which allows us to send `build_url`, `tag`, `slug` and `job`.