### PR TITLE
Fix issue where Circle CI Pull Request wasn't detected properly

### DIFF
--- a/codecov
+++ b/codecov
@@ -434,7 +434,7 @@ then
   branch="$CIRCLE_BRANCH"
   build="$CIRCLE_BUILD_NUM.$CIRCLE_NODE_INDEX"
   slug="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
-  pr="$CIRCLE_PR_NUMBER"
+  pr=$(echo "$CI_PULL_REQUEST" | grep -Eow "[0-9]+")
   commit="$CIRCLE_SHA1"
   search_in="$search_in $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS"
 


### PR DESCRIPTION
To add some clarification here, as mentioned in https://circleci.com/docs/environment-variables/, `CIRCLE_PR_NUMBER` only appears when a PR from a fork to a parent repository exists. I will need to modify this to use `CIRCLE_PR_NUMBER` if it exists, or the solution I have given if not. I'll get this done on Monday. Currently internal PR (same repository) are not exposed in codecov, when submitting with codecov-bash, inside CircleCI.