### PR TITLE
Use full path to YAML file to parse it

### DIFF
--- a/codecov
+++ b/codecov
@@ -733,7 +733,7 @@ yaml=$(echo "$yaml" | head -1)
 if [ "$yaml" != "" ];
 then
   say "    ${e}Yaml found at:${x} $yaml"
-  config=$(parse_yaml $yaml || echo '')
+  config=$(parse_yaml "$git_root/$yaml" || echo '')
 
   # TODO validate the yaml here
 


### PR DESCRIPTION
The argument to parse_yaml was passed as relative path to the repo root. When the script is run not from the repo root, the function is not able to find the config file.