### PR TITLE
typo: remove_addr => remote_addr

### DIFF
--- a/codecov
+++ b/codecov
@@ -464,7 +464,7 @@ then
   else
     commit="$BUILD_VCS_NUMBER"
   fi
-  remove_addr="$TEAMCITY_BUILD_REPOSITORY"
+  remote_addr="$TEAMCITY_BUILD_REPOSITORY"
 
 elif [ "$CI" = "true" ] && [ "$CIRCLECI" = "true" ];
 then
@@ -648,7 +648,7 @@ then
   service="gitlab"
   branch="$CI_BUILD_REF_NAME"
   build="$CI_BUILD_ID"
-  remove_addr="$CI_BUILD_REPO"
+  remote_addr="$CI_BUILD_REPO"
   commit="$CI_BUILD_REF"
 
 else


### PR DESCRIPTION
It looks like there was a typo in a few places in the script (under the gitlab and teamcity services) where the variable `remove_addr` was being set instead of `remote_addr`.

@stevepeak 