### PR TITLE
Add initial Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:latest
+RUN apk --update add bash curl git mercurial
+WORKDIR /app
+ADD codecov /codecov
+CMD ["/codecov"]


### PR DESCRIPTION
Building the image:
`docker build -t codecov .`

Using it, from within the folder with the coverage file:
`docker run -it -v $(pwd):/app codecov`