### PR TITLE
Add -y option to specify a .codecov.yml file

### DIFF
--- a/codecov
+++ b/codecov
@@ -38,6 +38,7 @@ ft_xcodeplist="0"
 
 _git_root=$(git rev-parse --show-toplevel 2>/dev/null || hg root 2>/dev/null || echo $PWD)
 git_root="$_git_root"
+codecov_yml=""
 remote_addr=""
 if [ "$git_root" = "$PWD" ];
 then
@@ -120,6 +121,7 @@ cat << EOF
                  -X network       Disable uploading the file network
 
     -R root dir  Used when not in git/hg project to identify project root directory
+    -y conf file Used to specify the location of the .codecov.yml config file
     -F flag      Flag the upload to group coverage metrics
 
                  -F unittests        This upload is only unittests
@@ -227,7 +229,7 @@ parse_yaml() {
 
 if [ $# != 0 ];
 then
-  while getopts "a:A:b:B:cC:dD:e:f:F:g:G:hJ:Kn:p:P:r:R:s:S:t:T:u:U:vx:X:Z" o
+  while getopts "a:A:b:B:cC:dD:e:f:F:g:G:hJ:Kn:p:P:r:R:y:s:S:t:T:u:U:vx:X:Z" o
   do
     case "$o" in
       "a")
@@ -324,6 +326,9 @@ $OPTARG"
         ;;
       "R")
         git_root="$OPTARG"
+        ;;
+      "y")
+        codecov_yml="$OPTARG"
         ;;
       "s")
         if [ "$search_in_o" = "" ];
@@ -755,8 +760,9 @@ then
   fi
 fi
 
-yaml=$(cd "$git_root" && \
-       git ls-files "*codecov.yml" "*codecov.yaml" 2>/dev/null \
+yaml=$(test -n "$codecov_yml" && echo "$codecov_yml" \
+       || cd "$git_root" && \
+           git ls-files "*codecov.yml" "*codecov.yaml" 2>/dev/null \
        || hg locate "*codecov.yml" "*codecov.yaml" 2>/dev/null \
        || echo '')
 yaml=$(echo "$yaml" | head -1)


### PR DESCRIPTION
When running in exported git repositories (for example) there will be no
"git_dir" present, so there should be a way to locate the .codecov.yml
file that doesn't depend on git.