### PR TITLE
Fix build directory location due to Xcode 9 changes

### DIFF
--- a/codecov
+++ b/codecov
@@ -187,7 +187,7 @@ urlencode() {
 
 
 swiftcov() {
-  _dir=$(dirname "$1")
+  _dir=$(dirname "$1" | sed 's/\(Build\).*/\1/g')
   for _type in app framework xctest
   do
     find "$_dir" -name "*.$_type" | while read f


### PR DESCRIPTION
With Xcode 9 `Coverage.profdata` resides in a different location. Look at the example.

/Users/distiller/Library/Developer/Xcode/DerivedData/Zewo-gcecuouhoxotyzgftixxatxncvem/Build/ProfileData/564D261E-47C4-4438-2AE3-56D166F5B432/Coverage.profdata

The change is compatible with Xcode 8 since it will just try to find it in a parent directory.