### PR TITLE
Enclose file name variable in quotes

### DIFF
--- a/codecov
+++ b/codecov
@@ -1245,7 +1245,7 @@ do
       then
         say "    ${g}+${x} $file ${e}bytes=$(echo "$report_len" | tr -d ' ')${x}"
         # append to to upload
-        _filename=$(basename $file)
+        _filename=$(basename "$file")
         if [ "${_filename##*.}" = 'gcov' ];
         then
           echo "# path=$(echo "$file.reduced" | sed "s|^$git_root/||")" >> $upload_file


### PR DESCRIPTION
If I am not mistaken (I am far from a Bash expert :-) ), the `$file` variable must be enclosed in quotes to ensure proper handling of spaces in the name. Otherwise each chunk of characters separated by a space are seen as a different argument by `basename`.

For example (a real case), if `$file` is not enclosed in quotes and its value is `./tests/karma-coverage/PhantomJS 2.1.1 (Linux 0.0.0)/lcov.info` the arguments received by `basename` would be `./tests/karma-coverage/PhantomJS`, `2.1.1`, `(Linux` and `0.0.0)/lcov.info` instead of a single one.
