### PR TITLE
Make script execute in a function

### DIFF
--- a/codecov
+++ b/codecov
@@ -414,6 +414,7 @@ $OPTARG"
   done
 fi
 
+main() {
 say "
   _____          _
  / ____|        | |
@@ -1548,3 +1549,6 @@ else
 fi
 
 exit ${exit_with}
+}
+
+main


### PR DESCRIPTION
If the script is only partially downloaded this can result in a pipefail
when doing:

```
curl -fsSL script_url | bash
```

This makes it so that the main function isn't actually executed until
the very end of the download.

This is the same type of pattern that we follow in [docker/docker-install](https://github.com/docker/docker-install)

Change was made without changes with indentation so that the diff won't be huge.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>