### PR TITLE
Fix clang support with 'llvm-cov gcov' as gcov_exe

### DIFF
--- a/codecov
+++ b/codecov
@@ -372,7 +372,12 @@ $OPTARG"
         curl_s=""
         ;;
       "x")
-        gcov_exe=$OPTARG
+        if [ -z "${OPTARG##*llvm-cov*}" ];
+        then
+          gcov_exe="$OPTARG gcov"
+        else
+          gcov_exe="$OPTARG"
+        fi
         ;;
       "X")
         if [ "$OPTARG" = "gcov" ];

--- a/codecov
+++ b/codecov
@@ -372,7 +372,7 @@ $OPTARG"
         curl_s=""
         ;;
       "x")
-        if [ -z "${OPTARG##*llvm-cov*}" ];
+        if [ -z "${OPTARG##*llvm-cov*}" -a -n "${OPTARG##*gcov*}" ];
         then
           gcov_exe="$OPTARG gcov"
         else


### PR DESCRIPTION
Fix #55. Users can specify the gcov executable as `llvm-cov`, `/usr/bin/llvm-cov-3.8`, or `llvm-cov gcov` with the `-x` option.
