### PR TITLE
Fix incorrect exit code on repeated failed upload

### DIFF
--- a/codecov
+++ b/codecov
@@ -1549,7 +1549,6 @@ else
 
     else
       say "    ${g}${res}${x}"
-      exit 0
       exit ${exit_with}
     fi
 


### PR DESCRIPTION
Caused [mui-org/material-ui/pull/14125/63488 (test_unit)](https://circleci.com/gh/mui-org/material-ui/63488?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) to exit with zero even if the upload failed and the script was called with `-Z`

Looks like an oversight in https://github.com/codecov/codecov-bash/commit/7c92b4e493d60e8891389e86a99d0b19485fe406#diff-45b1150df0237fb1cb2a238a2d04554eR991:
```diff
- exit $exit_with
+ exit 0
+ exit ${exit_with}
```