### PR TITLE
Call gcov once for all .gcno files

### DIFF
--- a/codecov
+++ b/codecov
@@ -952,7 +952,7 @@ then
   if [ "$ft_gcov" = "1" ];
   then
     say "${e}==>${x} Running gcov in $proj_root ${e}(disable via -X gcov)${x}"
-    bash -c "find $proj_root -type f -name '*.gcno' $gcov_include $gcov_ignore -execdir $gcov_exe -pb $gcov_arg {} +" || true
+    bash -c "find $proj_root -type f -name '*.gcno' $gcov_include $gcov_ignore -exec $gcov_exe -pb $gcov_arg {} +" || true
   else
     say "${e}==>${x} gcov disabled"
   fi


### PR DESCRIPTION
To avoid situations when files on different directory levels producing
same .gcov file.
    
`find` with` -execdir` executes `gcov` for each directory. If there are 2 .gcno
files on different directory levels each run may produce same .gcov file.
At the end only one file is left, so coverage report might be wrong.
