### PR TITLE
Make looking for a Travis language version variable stricter

### DIFF
--- a/codecov
+++ b/codecov
@@ -486,10 +486,10 @@ then
     branch="$TRAVIS_BRANCH"
   fi
 
-  language=$(printenv | grep "TRAVIS_.*_VERSION" | head -1)
+  language=$(compgen -A variable | grep "^TRAVIS_.*_VERSION$" | head -1)
   if [ "$language" != "" ];
   then
-    env="$env,${language%=*}"
+    env="$env,${!language}"
   fi
 
 elif [ "$DOCKER_REPO" != "" ];


### PR DESCRIPTION
Previously, codecov failed if "TRAVIS_.*_VERSION" occurred anywhere in
the value of a multi-line environment variable. Make the value lookup
stricter by first filtering the names only, and only later resolve any
value for a matching key.

Fixes #133.