### PR TITLE
Update readme.md with updated CI providers list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,9 +23,7 @@ chmod +x .codecov
 ------
 
 ### Languages
-> [Python](https://github.com/codecov/example-python), [C#/.net](https://github.com/codecov/example-csharp), [Java](https://github.com/codecov/example-java), [Node/Javascript/Coffee](https://github.com/codecov/example-node),
-> [C/C++](https://github.com/codecov/example-c), [D](https://github.com/codecov/example-d), [Go](https://github.com/codecov/example-go), [Groovy](https://github.com/codecov/example-groovy), [Kotlin](https://github.com/codecov/example-kotlin),
-> [PHP](https://github.com/codecov/example-php), [R](https://github.com/codecov/example-r), [Scala](https://github.com/codecov/example-scala), [Xtern](https://github.com/codecov/example-xtend), [Xcode](https://github.com/codecov/example-xcode), [Lua](https://github.com/codecov/example-lua) and more...
+> Codecov supports many languages, you can find a full list here: https://docs.codecov.io/docs/supported-languages
 
 
 ### Usage
@@ -92,8 +90,6 @@ bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverag
 | [Shippable](http://www.shippable.com/)              | Yes                                                                                                                                              | Public & Private |
 | [Gitlab CI](https://about.gitlab.com/gitlab-ci/)    | Yes                                                                                                                                              | Public & Private |
 | git                                                 | Yes (as a fallback)                                                                                                                              | Public & Private |
-| [Buildbot](http://buildbot.net/)                    | `coming soon` [buildbot/buildbot#1671](https://github.com/buildbot/buildbot/pull/1671)                                                           |                  |
-             |
 
 
 > Using **Travis CI**? Uploader is compatible with `sudo: false` which can speed up your builds. :+1:

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@ Codecov Global Uploader
 =======================
 > Upload reports to Codecov for almost every supported language.
 
-[![Deployed Version](https://codecov.io?bash=badge)](https://codecov.io?bash=redirect)
+[![Deployed Version](https://codecov.io/bash)](https://codecov.io/bash)
 
 ------
 
@@ -67,22 +67,34 @@ bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverag
 ### CI Providers
 |                       Company                       |                                                                    Supported                                                                     | Token Required   |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
-| [Travis CI](https://travis-ci.org/)                 | Yes [![Build Status](https://secure.travis-ci.org/codecov/codecov-bash.svg?branch=master)](http://travis-ci.org/codecov/codecov-bash)            | Private only     |
-| [CircleCI](https://circleci.com/)                   | Yes [![Circle CI](https://img.shields.io/circleci/project/codecov/codecov-bash.svg?branch=master)](https://circleci.com/gh/codecov/codecov-bash) | Private only     |
+| [Travis CI](https://travis-ci.org/)                 | Yes [![Build Status](https://secure.travis-ci.org/codecov/codecov-bash.svg?branch=master)](http://travis-ci.org/codecov/codecov-bash)            
+| Private only     |
+| [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) | Yes
+| Public & Private |
+| [CircleCI](https://circleci.com/)                   | Yes                    
+| Private only     |
 | [Codeship](https://codeship.com/)                   | Yes                                                                                                                                              | Public & Private |
 | [Jenkins](https://jenkins-ci.org/)                  | Yes                                                                                                                                              | Public & Private |
 | [Semaphore](https://semaphoreci.com/)               | Yes                                                                                                                                              | Public & Private |
+| [TeamCity](https://www.jetbrains.com/teamcity/).    | Yes
+| Public & Private |
 | [drone.io](https://drone.io/)                       | Yes                                                                                                                                              | Public & Private |
-| [AppVeyor](http://www.appveyor.com/)                | No. See [Codecov Python](https://github.com/codecov/codecov-python).                                                                             | Private only     |
+| [AppVeyor](http://www.appveyor.com/)                | Yes                                                                             | Private only     |
+| [Bamboo](https://www.atlassian.com/software/bamboo) | Yes                                                                                                                                    | Public & Private |
+| [Bitrise](https://bitrise.io/)                      | Yes                                                                                                                                    | Public & Private |
+| [buddybuild](https://buddybuild.com)                | Yes
+| Public & Private |
+| [Buildkite](https://buildkite.com)                  | Yes
+| Public & Private |
+| [Heroku](https://heroku.com)                        | Yes
+| Public & Private |
 | [Wercker](http://wercker.com/)                      | Yes                                                                                                                                              | Public & Private |
-| [Magnum CI](https://magnum-ci.com/)                 | Yes                                                                                                                                              | Public & Private |
 | [Shippable](http://www.shippable.com/)              | Yes                                                                                                                                              | Public & Private |
 | [Gitlab CI](https://about.gitlab.com/gitlab-ci/)    | Yes                                                                                                                                              | Public & Private |
 | git                                                 | Yes (as a fallback)                                                                                                                              | Public & Private |
 | [Buildbot](http://buildbot.net/)                    | `coming soon` [buildbot/buildbot#1671](https://github.com/buildbot/buildbot/pull/1671)                                                           |                  |
-| [Bamboo](https://www.atlassian.com/software/bamboo) | `coming soon`                                                                                                                                    |                  |
-| [Solano Labs](https://www.solanolabs.com/)          | `coming soon`                                                                                                                                    |                  |
-| [Bitrise](https://bitrise.io/)                      | `coming soon`                                                                                                                                    |                  |
+             |
+
 
 > Using **Travis CI**? Uploader is compatible with `sudo: false` which can speed up your builds. :+1:
 


### PR DESCRIPTION
* Update deployed link
* Remove CircleCI badge
* Update AppVeyor to Yes
* Update Bamboo to Yes
* Update Bitrise to Yes
* Add Teamcity
* Add Buddybuild
* Add Buildkite
* Add Heroku
* Add Azure Pipelines
* Remove Solano (dead site)
* Remove Magnum (invalid SSL cert)