### PR TITLE
Remove mention of Travis CI `sudo: false` in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,9 +87,6 @@ bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverag
 | git                                                 | Yes (as a fallback)                                                                                                                              | Public & Private |
 
 
-> Using **Travis CI**? Uploader is compatible with `sudo: false` which can speed up your builds. :+1:
-
-
 ## Caveat
 
 1. **Jenkins**: Unable to find reports? Try `PWD=WORKSPACE bash <(curl -s https://codecov.io/bash)`


### PR DESCRIPTION
The `sudo: false` option is now deprecated, see https://changelog.travis-ci.com/the-container-based-build-environment-is-fully-deprecated-84517.


## Purpose

This removes a reference to a deprecated Travis CI option.

## Notable Changes

N/A

## Tests and Risks?

No, as this is purely a documentation change.

## Update the SHA1SUM file

N/A