### PR TITLE
Recognize GitHub Actions

### DIFF
--- a/codecov
+++ b/codecov
@@ -764,6 +764,16 @@ then
   slug="$BITBUCKET_REPO_OWNER/$BITBUCKET_REPO_SLUG"
   job="$BITBUCKET_BUILD_NUMBER"
   pr="$BITBUCKET_PR_ID"
+elif [ "$GITHUB_WORKFLOW" != "" ];
+then
+  say "$e==>$x GitHub Actions detected."
+  # https://help.github.com/en/articles/virtual-environments-for-github-actions#environment-variables
+  service="github"
+  branch="${GITHUB_REF}"
+  build="${GITHUB_ACTION}"
+  commit="${GITHUB_SHA}"
+  slug="${GITHUB_REPOSITORY}"
+
 else
   say "${r}x>${x} No CI provider detected."
   say "    Testing inside Docker? ${b}http://docs.codecov.io/docs/testing-with-docker${x}"


### PR DESCRIPTION
## Purpose
Recognize the GitHub Actions environment.

## Notable Changes
I'm not sure whether some other changes are needed.

## Tests and Risks?
Not covered by tests.

## Update the SHA1SUM file
I did the edit on GitHub, currently I can't update that: Also make sure that you update the sha1 hash by running `sha1sum codecov` and updating the SHA1SUM file with the output Change the `codecov` to `-` in the file before commiting so it can be compared against the server file 