### PR TITLE
Add Cirrus CI support

### DIFF
--- a/codecov
+++ b/codecov
@@ -513,6 +513,16 @@ then
   build_url=$(urlencode "$CI_BUILD_URL")
   commit="$CI_COMMIT_ID"
 
+elif [ "$CI" = "true" ] && [ "$CIRRUS_CI" = "true" ];
+then
+  say "$e==>$x Cirrus CI detected."
+  # https://cirrus-ci.org/guide/writing-tasks/#environment-variables
+  service="cirrus"
+  branch="$CIRRUS_BRANCH"
+  build="$"
+  build_url="https://cirrus-ci.com"
+  commit="$CIRRUS_CHANGE_IN_REPO"
+
 elif [ ! -z "$CF_BUILD_URL" ] && [ ! -z "$CF_BUILD_ID" ];
 then
   say "$e==>$x Codefresh CI detected."

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverag
 | [Travis CI](https://travis-ci.org/)                 | Yes [![Build Status](https://secure.travis-ci.org/codecov/codecov-bash.svg?branch=master)](http://travis-ci.org/codecov/codecov-bash)                                                         | Private only     |
 | [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) | Yes                                     | Public & Private |
 | [CircleCI](https://circleci.com/)                   | Yes                                                                 | Private only     |
+| [Cirrus CI](https://cirrus-ci.org/).                | Yes                                                                 | Public & Private |
 | [Codeship](https://codeship.com/)                   | Yes                                                                                                                  | Public & Private |
 | [Jenkins](https://jenkins-ci.org/)                  | Yes                                                                                                          | Public & Private |
 | [Semaphore](https://semaphoreci.com/)               | Yes                                                                 | Public & Private |


### PR DESCRIPTION
## Purpose
Adds support for Cirrus CI.  

## Notable Changes
Adds a new CI provider

## Tests and Risks?
Should be.

## Update the SHA1SUM file

Also make sure that you update the sha1 hash by running `sha1sum codecov` and updating the SHA1SUM file with the output
Change the `codecov` to `-` in the file before commiting so it can be compared against the server file 




