### PR TITLE
Remove 'job' variable from Actions

### DIFF
--- a/codecov
+++ b/codecov
@@ -763,7 +763,6 @@ then
   branch="${GITHUB_REF#refs/heads/}"
   commit="${GITHUB_SHA}"
   slug="${GITHUB_REPOSITORY}"
-  job="${GITHUB_ACTION}"
 
 elif [ "$SYSTEM_TEAMFOUNDATIONSERVERURI" != "" ];
 then

--- a/tests/test
+++ b/tests/test
@@ -340,7 +340,7 @@ function test_github_action () {
     export GITHUB_REPOSITORY="codecov/ci-repo"
     export GITHUB_SHA="$TEST_DATA_GIT_COMMIT"
 
-    assertURL "https://codecov.io/upload/v4?package=bash-$VERSION&token=&branch=master&commit=$TEST_DATA_GIT_COMMIT&build=&build_url=&name=&tag=&slug=codecov%2Fci-repo&service=github-actions&flags=&pr=&job=$GITHUB_ACTION"
+    assertURL "https://codecov.io/upload/v4?package=bash-$VERSION&token=&branch=master&commit=$TEST_DATA_GIT_COMMIT&build=&build_url=&name=&tag=&slug=codecov%2Fci-repo&service=github-actions&flags=&pr=&job="
 }
 
 function test_semaphore (){


### PR DESCRIPTION
## Purpose
There is no env variable that links back to the build/job



