### PR TITLE
Option to disable gcov output ignored for non Obj-C projects

### DIFF
--- a/SHA1SUM
+++ b/SHA1SUM
@@ -1,1 +1,1 @@
-a83ea0775de75ea41bf1ad957d7155b178be9bcf  codecov
+9a2dca86062da581d8eccf9393bdb0f74ae4e878  codecov

--- a/codecov
+++ b/codecov
@@ -1044,7 +1044,13 @@ then
   if [ "$ft_gcov" = "1" ];
   then
     say "${e}==>${x} Running gcov in $proj_root ${e}(disable via -X gcov)${x}"
-    bash -c "find $proj_root -type f -name '*.gcno' $gcov_include $gcov_ignore -execdir $gcov_exe -pb $gcov_arg {} \;" || true
+    if [ "$ft_gcovout" = "1" ];
+    then
+      # suppress gcov output
+      bash -c "find $proj_root -type f -name '*.gcno' $gcov_include $gcov_ignore -execdir $gcov_exe -pb $gcov_arg {} \;" || true 2>/dev/null
+    else
+      bash -c "find $proj_root -type f -name '*.gcno' $gcov_include $gcov_ignore -execdir $gcov_exe -pb $gcov_arg {} \;" || true
+    fi
   else
     say "${e}==>${x} gcov disabled"
   fi


### PR DESCRIPTION
## Purpose
The option "-X gcovout" to disable the output of gcov is only used in Obj-C projects. For other projects this option is ignored. Fixed this in the same way it's done for Obj-C.

## Notable Changes
None.

## Tests and Risks?
None.

## Update the SHA1SUM file
Done.


