### PR TITLE
Use maxdepth as part of find

### DIFF
--- a/codecov
+++ b/codecov
@@ -916,7 +916,7 @@ yaml=$(test -n "$codecov_yml" && echo "$codecov_yml" \
        || cd "$git_root" && \
           git ls-files "*codecov.yml" "*codecov.yaml" 2>/dev/null \
        || hg locate "*codecov.yml" "*codecov.yaml" 2>/dev/null \
-       || cd $proj_root && find . -type f -name '*codecov.y*ml' -depth 1 2>/dev/null \
+       || cd $proj_root && find . -maxdepth 1 -type f -name '*codecov.y*ml' 2>/dev/null \
        || echo '')
 yaml=$(echo "$yaml" | head -1)
 


### PR DESCRIPTION
See #264

## Purpose
Fix issue #264

## Notable Changes
Are there any changes that need to be called out as particularly tricky or significant?

## Tests and Risks?
Is this covered by existing tests? New ones? If no, why not?

## Update the SHA1SUM file

Also make sure that you update the sha1 hash by running `sha1sum codecov` and updating the SHA1SUM file with the output
