### PR TITLE
fix: docs for development

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,18 @@ bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverag
 | git                                                 | Yes (as a fallback)                                                                                                                              | Public & Private |
 
 
-## Caveat
+### Caveats
 
 1. **Jenkins**: Unable to find reports? Try `PWD=WORKSPACE bash <(curl -s https://codecov.io/bash)`
  
+
+
+### Development
+
+Once you made a change to the codecov uploader script, please also update the hash file via:
+
+```bash
+shasum codecov > SHA1SUM
+```
+
+and add the change to your pull request.


### PR DESCRIPTION
re https://github.com/codecov/codecov-bash/pull/147#issuecomment-594236351 (@drazisil)

When opening a pull request from command line it is not immediately obvious that this needs to be done and looking into the .github/ folder is not something a lot of people would do either.

