### PR TITLE
Update CodeBuild support for basic integration with GitHub Enterprise.

### DIFF
--- a/SHA1SUM
+++ b/SHA1SUM
@@ -1,1 +1,1 @@
-bbca7fc50d331ab737e49f9f7f90aca5b2f0d1d2  codecov
+352a2522e84ef9e43e77e37831280b3515cb895c  codecov

--- a/codecov
+++ b/codecov
@@ -514,7 +514,7 @@ then
     pr="$(echo $CODEBUILD_SOURCE_VERSION | sed 's/^pr\///')"
   fi
   job="$CODEBUILD_BUILD_ID"
-  slug="$(echo $CODEBUILD_SOURCE_REPO_URL | sed 's/^.*github.com\///' | sed 's/^.*bitbucket.org\///' | sed 's/\.git$//')"
+  slug="$(echo $CODEBUILD_SOURCE_REPO_URL | sed 's/^.*:\/\/[^\/]*\///' | sed 's/\.git$//')"
 
 elif [ "$DOCKER_REPO" != "" ];
 then

--- a/tests/test
+++ b/tests/test
@@ -272,6 +272,17 @@ function test_codebuild_with_bitbucket_repo () {
     assertURL "https://codecov.io/upload/v4?package=bash-$VERSION&token=&branch=codebuild-master&commit=$TEST_DATA_GIT_COMMIT&build=33116958&build_url=&name=&tag=&slug=owner%2Frepo&service=codebuild&flags=&pr=false&job=33116958"
 }
 
+function test_codebuild_with_nonpublic_github_host () {
+    reset
+    export CODEBUILD_CI="true"
+    export CODEBUILD_WEBHOOK_HEAD_REF="refs/heads/codebuild-master"
+    export CODEBUILD_RESOLVED_SOURCE_VERSION="$TEST_DATA_GIT_COMMIT"
+    export CODEBUILD_SOURCE_VERSION="$TEST_DATA_GIT_COMMIT"
+    export CODEBUILD_BUILD_ID="33116958"
+    export CODEBUILD_SOURCE_REPO_URL="https://github-enterprise.example.com/codecov/codecov-bash.git"
+    assertURL "https://codecov.io/upload/v4?package=bash-$VERSION&token=&branch=codebuild-master&commit=$TEST_DATA_GIT_COMMIT&build=33116958&build_url=&name=&tag=&slug=codecov%2Fcodecov-bash&service=codebuild&flags=&pr=false&job=33116958"
+}
+
 function test_travis () {
     reset
     export CI="true"


### PR DESCRIPTION
## Purpose
What is the context of this pull request? Why is it being done?

This adds basic support for non-public GitHub Enterprise on AWS CodeBuild. We recently found that this didn't "just work" due to the slug being incorrectly determined. The uploader would make multiple attempts before failing with:

```
...
    HTTP 400
slug must match pattern ^[\w\-\.\~\/]+\/[\w\-\.]{1,255}$
```

We noticed that in the upload request to our Codecov Enterprise server, the `slug` url param was the full repo url instead of the expected `org/repo` format (`&slug=https%3A%2F%2Fgit-instance.example.com%2Ffoo-org%2Fbar-repo&....`).

This should help a bit with codecov/codecov-bash#250.

## Notable Changes
Are there any changes that need to be called out as particularly tricky or significant?

This does remove the explicit domain matching that was previously in place as customers will not be using the previous domains for hosting their GitHub Enterprise instance.

## Tests and Risks?
Is this covered by existing tests? New ones? If no, why not?

A new test was added for this.

## Update the SHA1SUM file

Also make sure that you update the sha1 hash by running `sha1sum codecov` and updating the SHA1SUM file with the output

The SHA1SUM file has been updated.
