### PR TITLE
Remove public-read header

### DIFF
--- a/SHA1SUM
+++ b/SHA1SUM
@@ -1,1 +1,1 @@
-352a2522e84ef9e43e77e37831280b3515cb895c  codecov
+00a587cad2ddfedbee35dc0b2e8ed7e35109c4f4  codecov

--- a/codecov
+++ b/codecov
@@ -1637,7 +1637,6 @@ else
             --data-binary @$upload_file.gz \
             -H 'Content-Type: application/x-gzip' \
             -H 'Content-Encoding: gzip' \
-             -H 'x-amz-acl: public-read' \
             "$s3target" || true)
 
 


### PR DESCRIPTION
## Purpose
Changes to codecov uploading infrastructure mean the public-read header is no longer required. This PR removes the header.

## Notable Changes
Removal of `X-Amz-Acl: public-read`

## Update the SHA1SUM file
https://github.com/codecov/codecov-bash/pull/302/commits/636a4221330da27a61db2d8474de9ede92fd8bd4