### PR TITLE
Fix envs for GitHub Actions

### DIFF
--- a/env
+++ b/env
@@ -253,6 +253,7 @@ then
 elif [ "$GITHUB_ACTIONS" != '' ]
 then
   add "GITHUB_ACTION"
+  add "GITHUB_ACTIONS"
   add "GITHUB_REF"
   add "GITHUB_REPOSITORY"
   add "GITHUB_HEAD_REF"


### PR DESCRIPTION
## Purpose
`GITHUB_ACTIONS` was not passed to docker container by `env` script.
It is used at 
https://github.com/codecov/codecov-bash/blob/8b64f2c07d9ebc2ea2c61419009179945acbf044/codecov#L797

## Notable Changes
no notable changes

## Tests and Risks?
`env` script seems not covered by the existing tests.

## Update the SHA hash files
`codecov` script is not changed.