### PR TITLE
add DRONE_COMMIT

### DIFF
--- a/codecov
+++ b/codecov
@@ -707,10 +707,9 @@ then
 elif [ "$CI" = "drone" ] || [ "$DRONE" = "true" ];
 then
   say "$e==>$x Drone CI detected."
-  # http://docs.drone.io/env.html
-  # drone commits are not full shas
   service="drone.io"
   branch="$DRONE_BRANCH"
+  commit="$DRONE_COMMIT"
   build="$DRONE_BUILD_NUMBER"
   build_url=$(urlencode "${DRONE_BUILD_LINK}")
   pr="$DRONE_PULL_REQUEST"


### PR DESCRIPTION
## Purpose
In testing, codecov-bash was uploading reports to the wrong commit SHA when using drone ci.   
It is unclear where it was getting the incorrect value from.
This code, outside of the codecov-bash script, did seem to help.
export VCS_COMMIT_ID=$DRONE_COMMIT
export GIT_COMMIT=$DRONE_COMMIT

The previous comment "drone commits are not full shas" was written in 2015 and may be obsolete now.
