### PR TITLE
Verify only SHA512 checksum

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,23 +28,8 @@ As an additional layer of security, users may wish to check the script against t
 
 ```bash
 curl -fLso codecov https://codecov.io/bash;
-VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
-for i in 1 256 512
-do
-  shasum -a $i -c --ignore-missing <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM")
-done
-./codecov
-```
-
-or for older versions of `shasum`
-
-```bash
-curl -fLso codecov https://codecov.io/bash;
-VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
-for i in 1 256 512
-do
-  shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM" | grep -w "codecov")
-done
+VERSION=$(grep -o 'VERSION=\"[0-9.]*\"' codecov | cut -d'"' -f2);
+shasum -a 512 -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM" | grep -w "codecov")
 ./codecov
 ```
 


### PR DESCRIPTION
It is waste of time to download 3 files and check with weaker algorithms. It is enough to download one file and check with strongest algorithm SHA512.

Leave only "for older versions" part for less confusion when selecting correct snippet. `grep codecov`  is same as `--ignore-missing`.

Also, it is unnecessary to escape `.` inside `[ ]` of regular expression.