### PR TITLE
fail if release fails. fixes #446

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -x -e
 
 clear_branch () {
   # Clear changes


### PR DESCRIPTION
## Purpose
Your other packages e.g. https://github.com/codecov/codecov-circleci-orb rely on the assumption that published versions are versioned in github c.f. https://github.com/codecov/codecov-circleci-orb/issues/92 . However if a new version of codecov is added without the version string bumped, then you will publish the bash script but not version in github because not all errors in the version.sh script (without this change) are caught and passed out to CircleCI. 

## Notable Changes
Because of the way this change then interacts with the existing .circleci/config.yml script, errors on versioning will now be caught and prevent publishing if there is a problem, preventing this mismatch in future.

This will rely on the version string in the codecov script being updated when you want to release (which is required for changes to the bash script), and noting I haven't done this as I wanted to keep this PR for just the issue at hand and didn't want to force a release on merge.

## Tests and Risks?
It adds a test in your CI to ensure that all parts of version.sh run.

## Update the SHA hash files

n/a - a change to your CI script
